### PR TITLE
Update pyximc-template.py

### DIFF
--- a/wrappers/python/pyximc-template.py
+++ b/wrappers/python/pyximc-template.py
@@ -15,7 +15,7 @@ def ximc_shared_lib():
         return CDLL("libximc.framework/libximc")
     elif platform.system() == "Windows":
         if sys.version_info[0] == 3 and sys.version_info[0] >= 8:
-            WinDLL("libximc.dll", winmode=RTLD_GLOBAL)
+            return WinDLL("libximc.dll", winmode=RTLD_GLOBAL)
         else:
             return WinDLL("libximc.dll")
     else:


### PR DESCRIPTION
ximc_shared_lib should provide handle on python 3.9 as well :)
Probably a typo on original codebase.